### PR TITLE
Handle directories in url_stat()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,11 @@
             "Elazar\\Flystream\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Elazar\\Flystream\\Tests\\": "tests/"
+        }
+    },
     "scripts": {
         "cs": "php-cs-fixer fix",
         "test": "XDEBUG_MODE=coverage pest --coverage"

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -373,14 +373,14 @@ class StreamWrapper
 
         if ($filesystem->fileExists($path)) {
             $mode = 0100000 | $visibility->forFile(
-                    $filesystem->visibility($path)
-                );
+                $filesystem->visibility($path)
+            );
             $size =  $filesystem->fileSize($path);
             $mtime = $filesystem->lastModified($path);
-        } else if ($filesystem->directoryExists($path)) {
+        } elseif ($filesystem->directoryExists($path)) {
             $mode = 0040000 | $visibility->forDirectory(
-                    $filesystem->visibility($path)
-                );
+                $filesystem->visibility($path)
+            );
             $size =  0;
             $mtime = $filesystem->lastModified($path);
         } else {

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -426,7 +426,7 @@ class StreamWrapper
      * parse_url() chokes on path-less URLs (like foo://), so in that case, fall back to manual parsing.
      *
      * @param string $path
-     * @return string
+     * @return string|null
      */
     private function getProtocol(string $path): ?string
     {

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -2,9 +2,9 @@
 
 use Elazar\Flystream\FilesystemRegistry;
 use Elazar\Flystream\ServiceLocator;
+use Elazar\Flystream\Tests\TestInMemoryFilesystemAdapter;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\Filesystem;
-use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use League\Flysystem\PathNormalizer;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -20,7 +20,11 @@ beforeEach(function () {
 
     $this->registry = ServiceLocator::get(FilesystemRegistry::class);
 
-    $this->filesystem = new Filesystem(new InMemoryFilesystemAdapter);
+    $this->filesystem = new Filesystem(
+        new TestInMemoryFilesystemAdapter,
+        [],
+        ServiceLocator::get(PathNormalizer::class),
+    );
     $this->registry->register('fly', $this->filesystem);
 });
 
@@ -76,7 +80,7 @@ it('can iterate over a non-empty directory', function () {
     fclose($file);
     $dir = opendir('fly://foo');
     $result = readdir($dir);
-    expect($result)->toBe('fly:/foo/bar');
+    expect($result)->toBe('foo/bar');
     closedir($dir);
 });
 
@@ -86,10 +90,10 @@ it('can rewind a directory iterator', function () {
     fclose($file);
     $dir = opendir('fly://foo');
     $result = readdir($dir);
-    expect($result)->toBe('fly:/foo/bar');
+    expect($result)->toBe('foo/bar');
     rewinddir($dir);
     $result = readdir($dir);
-    expect($result)->toBe('fly:/foo/bar');
+    expect($result)->toBe('foo/bar');
     closedir($dir);
 });
 
@@ -269,19 +273,11 @@ it('supports stream selection', function () {
 });
 
 it('can read and write to a Flysystem filesystem', function () {
-    $this->filesystem = new Filesystem(
-        new InMemoryFilesystemAdapter(),
-        [],
-        ServiceLocator::get(PathNormalizer::class),
-    );
-    $this->registry->register('mem', $this->filesystem);
-
     $path = 'foo';
     $expected = 'bar';
     $this->filesystem->write($path, $expected);
 
-    $actual = file_get_contents("mem://$path");
-    $this->registry->unregister('mem');
+    $actual = file_get_contents("fly://$path");
 
     expect($actual)->toBe($expected);
 });

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -34,6 +34,12 @@ it('can create and delete directories', function () {
     rmdir('fly://foo');
 });
 
+it('can detect a directory', function () {
+    mkdir('fly://foo');
+    expect(is_dir('fly://foo'))->toBeTrue();
+    rmdir('fly://foo');
+});
+
 it('can copy an empty file', function () {
     $success = touch('fly://src');
     expect($success)->toBe(true);

--- a/tests/TestInMemoryFilesystemAdapter.php
+++ b/tests/TestInMemoryFilesystemAdapter.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Elazar\Flystream\Tests;
+
+use League\MimeTypeDetection\{
+    FinfoMimeTypeDetector,
+    MimeTypeDetector,
+};
+use League\Flysystem\{
+    Config,
+    FileAttributes,
+    FilesystemAdapter,
+    InMemory\InMemoryFilesystemAdapter,
+    Visibility,
+};
+
+/**
+ * InMemoryFilesystemAdapter has suboptimal handling of directories; this
+ * adapter wraps it to provide better support for them.
+ */
+class TestInMemoryFilesystemAdapter implements FilesystemAdapter
+{
+    /** @var InMemoryFilesystemAdapter */
+    private InMemoryFilesystemAdapter $adapter;
+
+    /** @var array<string, FileAttributes> */
+    private array $directories;
+
+    public function __construct(
+        private string $defaultVisibility = Visibility::PUBLIC,
+        ?MimeTypeDetector $mimeTypeDetector = null
+    ) {
+        $this->adapter = new InMemoryFilesystemAdapter(
+            $defaultVisibility,
+            $mimeTypeDetector ?? new FinfoMimeTypeDetector,
+        );
+        $this->directories = [];
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        unset($this->directories[$this->preparePath($path)]);
+
+        $this->adapter->deleteDirectory($path);
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        $directoryPath = $this->preparePath($path);
+        $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
+        $lastModified = $config->get('timestamp') ?? 0;
+        $this->directories[$directoryPath] = new FileAttributes(
+            $directoryPath,
+            0,
+            $visibility,
+            $lastModified,
+        );
+
+        $this->adapter->createDirectory($path, $config);
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        return isset($this->directories[$this->preparePath($path)]);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $directoryPath = $this->preparePath($path);
+        if ($this->directoryExists($directoryPath)) {
+            $this->directories[$directoryPath] = new FileAttributes(
+                $directoryPath,
+                0,
+                $visibility,
+                time()
+            );
+        }
+
+        $this->adapter->setVisibility($path, $visibility);
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        $directoryPath = $this->preparePath($path);
+        return $this->directories[$directoryPath]
+            ?? $this->adapter->visibility($path);
+    }
+
+    public function lastModified(string $path): FileAttributes
+    {
+        $directoryPath = $this->preparePath($path);
+        return $this->directories[$directoryPath]
+            ?? $this->adapter->lastModified($path);
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return $this->adapter->fileExists($path);
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        $this->adapter->write($path, $contents, $config);
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->adapter->writeStream($path, $contents, $config);
+    }
+
+    public function read(string $path): string
+    {
+        return $this->adapter->read($path);
+    }
+
+    public function readStream(string $path)
+    {
+        return $this->adapter->readStream($path);
+    }
+
+    public function delete(string $path): void
+    {
+        $this->adapter->delete($path);
+    }
+
+    public function mimeType(string $path): FileAttributes
+    {
+        return $this->adapter->mimeType($path);
+    }
+
+    public function fileSize(string $path): FileAttributes
+    {
+        return $this->adapter->fileSize($path);
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return $this->adapter->listContents($path, $deep);
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        $this->adapter->move($source, $destination, $config);
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        $this->adapter->copy($source, $destination, $config);
+    }
+
+    private function preparePath(string $path): string
+    {
+        return '/' . trim($path, '/') . '/';
+    }
+}
+

--- a/tests/TestInMemoryFilesystemAdapter.php
+++ b/tests/TestInMemoryFilesystemAdapter.php
@@ -32,7 +32,7 @@ class TestInMemoryFilesystemAdapter implements FilesystemAdapter
     ) {
         $this->adapter = new InMemoryFilesystemAdapter(
             $defaultVisibility,
-            $mimeTypeDetector ?? new FinfoMimeTypeDetector,
+            $mimeTypeDetector ?? new FinfoMimeTypeDetector(),
         );
         $this->directories = [];
     }
@@ -153,4 +153,3 @@ class TestInMemoryFilesystemAdapter implements FilesystemAdapter
         return '/' . trim($path, '/') . '/';
     }
 }
-


### PR DESCRIPTION
There's two bugs here to fix.

1. `parse_url()` cannot handle `foo://` style strings.  It just returns false.  So in that case we need to manually parse the string.  (This is arguably a core bug, but there's already an Internals thread about how to replace `parse_url()` with something that sucks less.)
2. `Filesystem::fileSize()` chokes on a directory, which makes `url_stat()` fail on directories.

This patch fixes both, and causes my test cases to work in my app.  However!  The new test I added here still fails with a visibility error.  I cannot get my CLI debugger connected properly on this app and cannot run Pest tests directly from IntelliJ (just PHPUnit), so I cannot reasonably debug further myself.