### PR TITLE
Update `::url_stat()` for directories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,11 @@
             "Elazar\\Flystream\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Elazar\\Flystream\\Tests\\": "tests/"
+        }
+    },
     "scripts": {
         "cs": "php-cs-fixer fix",
         "test": "XDEBUG_MODE=coverage pest --coverage"

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -128,6 +128,7 @@ class StreamWrapper
         $filesystem = $this->getFilesystem($path);
         try {
             $filesystem->deleteDirectory($path);
+            clearstatcache();
             return true;
 
             // @codeCoverageIgnoreStart

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -52,7 +52,7 @@ it('can detect, create, and delete directories', function () {
     $rmResult = rmdir('fly://foo');
     expect($rmResult)->toBeTrue();
     $this->assertFalse(is_dir('fly://foo'));
-})->only();
+});
 
 it('handles opening a nonexistent directory', function () {
     $dir = opendir('fly://foo');

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -51,7 +51,6 @@ it('can detect, create, and delete directories', function () {
     $this->assertTrue(is_dir('fly://foo'));
     $rmResult = rmdir('fly://foo');
     expect($rmResult)->toBeTrue();
-    clearstatcache();
     $this->assertFalse(is_dir('fly://foo'));
 })->only();
 

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -42,15 +42,11 @@ afterEach(function () {
 
 it('can detect, create, and delete directories', function () {
     $this->assertFalse(is_dir('fly://foo'));
-
     $mkResult = mkdir('fly://foo');
     expect($mkResult)->toBeTrue();
-
     $this->assertTrue(is_dir('fly://foo'));
-
     $rmResult = rmdir('fly://foo');
     expect($rmResult)->toBeTrue();
-
     $this->assertFalse(is_dir('fly://foo'));
 })->only();
 

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -51,6 +51,7 @@ it('can detect, create, and delete directories', function () {
     $this->assertTrue(is_dir('fly://foo'));
     $rmResult = rmdir('fly://foo');
     expect($rmResult)->toBeTrue();
+    clearstatcache();
     $this->assertFalse(is_dir('fly://foo'));
 })->only();
 

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -40,11 +40,19 @@ afterEach(function () {
     $this->registry->unregister('fly');
 });
 
-it('can create and delete directories', function () {
-    $result = mkdir('fly://foo');
-    expect($result)->toBeTrue();
-    rmdir('fly://foo');
-});
+it('can detect, create, and delete directories', function () {
+    $this->assertFalse(is_dir('fly://foo'));
+
+    $mkResult = mkdir('fly://foo');
+    expect($mkResult)->toBeTrue();
+
+    $this->assertTrue(is_dir('fly://foo'));
+
+    $rmResult = rmdir('fly://foo');
+    expect($rmResult)->toBeTrue();
+
+    $this->assertFalse(is_dir('fly://foo'));
+})->only();
 
 it('handles opening a nonexistent directory', function () {
     $dir = opendir('fly://foo');

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -32,7 +32,9 @@ beforeEach(function () {
 
     $this->registry = $container[FilesystemRegistry::class];
 
-    $this->filesystem = new Filesystem(new InMemoryFilesystemAdapter());
+    $pathNormalizer = ServiceLocator::getInstance()->getContainer()[PathNormalizer::class];
+    $this->filesystem = new Filesystem(new InMemoryFilesystemAdapter(), [], $pathNormalizer);
+
     $this->registry->register('fly', $this->filesystem);
 });
 

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -2,9 +2,9 @@
 
 use Elazar\Flystream\FilesystemRegistry;
 use Elazar\Flystream\ServiceLocator;
+use Elazar\Flystream\Tests\TestInMemoryFilesystemAdapter;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\Filesystem;
-use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use League\Flysystem\PathNormalizer;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -32,9 +32,11 @@ beforeEach(function () {
 
     $this->registry = $container[FilesystemRegistry::class];
 
-    $pathNormalizer = ServiceLocator::getInstance()->getContainer()[PathNormalizer::class];
-    $this->filesystem = new Filesystem(new InMemoryFilesystemAdapter(), [], $pathNormalizer);
-
+    $this->filesystem = new Filesystem(
+        new TestInMemoryFilesystemAdapter,
+        [],
+        ServiceLocator::get(PathNormalizer::class),
+    );
     $this->registry->register('fly', $this->filesystem);
 });
 
@@ -74,7 +76,7 @@ it('can iterate over a non-empty directory', function () {
     fclose($file);
     $dir = opendir('fly://foo');
     $result = readdir($dir);
-    expect($result)->toBe('fly:/foo/bar');
+    expect($result)->toBe('foo/bar');
     closedir($dir);
 });
 
@@ -84,10 +86,10 @@ it('can rewind a directory iterator', function () {
     fclose($file);
     $dir = opendir('fly://foo');
     $result = readdir($dir);
-    expect($result)->toBe('fly:/foo/bar');
+    expect($result)->toBe('foo/bar');
     rewinddir($dir);
     $result = readdir($dir);
-    expect($result)->toBe('fly:/foo/bar');
+    expect($result)->toBe('foo/bar');
     closedir($dir);
 });
 
@@ -267,19 +269,11 @@ it('supports stream selection', function () {
 });
 
 it('can read and write to a Flysystem filesystem', function () {
-    $this->filesystem = new Filesystem(
-        new InMemoryFilesystemAdapter(),
-        [],
-        ServiceLocator::get(PathNormalizer::class),
-    );
-    $this->registry->register('mem', $this->filesystem);
-
     $path = 'foo';
     $expected = 'bar';
     $this->filesystem->write($path, $expected);
 
-    $actual = file_get_contents("mem://$path");
-    $this->registry->unregister('mem');
+    $actual = file_get_contents("fly://$path");
 
     expect($actual)->toBe($expected);
 });

--- a/tests/TestInMemoryFilesystemAdapter.php
+++ b/tests/TestInMemoryFilesystemAdapter.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Elazar\Flystream\Tests;
+
+use League\MimeTypeDetection\{
+    FinfoMimeTypeDetector,
+    MimeTypeDetector,
+};
+use League\Flysystem\{
+    Config,
+    FileAttributes,
+    FilesystemAdapter,
+    InMemory\InMemoryFilesystemAdapter,
+    Visibility,
+};
+
+/**
+ * InMemoryFilesystemAdapter has suboptimal handling of directories; this
+ * adapter wraps it to provide better support for them.
+ */
+class TestInMemoryFilesystemAdapter implements FilesystemAdapter
+{
+    /** @var InMemoryFilesystemAdapter */
+    private InMemoryFilesystemAdapter $adapter;
+
+    /** @var array<string, FileAttributes> */
+    private array $directories;
+
+    public function __construct(
+        private string $defaultVisibility = Visibility::PUBLIC,
+        ?MimeTypeDetector $mimeTypeDetector = null
+    ) {
+        $this->adapter = new InMemoryFilesystemAdapter(
+            $defaultVisibility,
+            $mimeTypeDetector ?? new FinfoMimeTypeDetector,
+        );
+        $this->directories = [];
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        unset($this->directories[$this->preparePath($path)]);
+
+        $this->adapter->deleteDirectory($path);
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        $directoryPath = $this->preparePath($path);
+        $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
+        $lastModified = $config->get('timestamp') ?? 0;
+        $this->directories[$directoryPath] = new FileAttributes(
+            $directoryPath,
+            0,
+            $visibility,
+            $lastModified,
+        );
+
+        $this->adapter->createDirectory($path, $config);
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        return isset($this->directories[$this->preparePath($path)]);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $directoryPath = $this->preparePath($path);
+        if ($this->directoryExists($directoryPath)) {
+            $this->directories[$directoryPath] = new FileAttributes(
+                $directoryPath,
+                0,
+                $visibility,
+                time()
+            );
+        }
+
+        $this->adapter->setVisibility($path, $visibility);
+    }
+
+    public function visibility(string $path): FileAttributes
+    {
+        $directoryPath = $this->preparePath($path);
+        return $this->directories[$directoryPath]
+            ?? $this->adapter->visibility($path);
+    }
+
+    public function lastModified(string $path): FileAttributes
+    {
+        $directoryPath = $this->preparePath($path);
+        return $this->directories[$directoryPath]
+            ?? $this->adapter->lastModified($path);
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return $this->adapter->fileExists($path);
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        $this->adapter->write($path, $contents, $config);
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->adapter->writeStream($path, $contents, $config);
+    }
+
+    public function read(string $path): string
+    {
+        return $this->adapter->read($path);
+    }
+
+    public function readStream(string $path)
+    {
+        return $this->adapter->readStream($path);
+    }
+
+    public function delete(string $path): void
+    {
+        $this->adapter->delete($path);
+    }
+
+    public function mimeType(string $path): FileAttributes
+    {
+        return $this->adapter->mimeType($path);
+    }
+
+    public function fileSize(string $path): FileAttributes
+    {
+        return $this->adapter->fileSize($path);
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return $this->adapter->listContents($path, $deep);
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        $this->adapter->move($source, $destination, $config);
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        $this->adapter->copy($source, $destination, $config);
+    }
+
+    private function preparePath(string $path): string
+    {
+        return '/' . trim($path, '/') . '/';
+    }
+}
+

--- a/tests/TestInMemoryFilesystemAdapter.php
+++ b/tests/TestInMemoryFilesystemAdapter.php
@@ -26,14 +26,17 @@ class TestInMemoryFilesystemAdapter implements FilesystemAdapter
     /** @var array<string, FileAttributes> */
     private array $directories;
 
+    private string $defaultVisibility;
+
     public function __construct(
-        private string $defaultVisibility = Visibility::PUBLIC,
+        string $defaultVisibility = Visibility::PUBLIC,
         ?MimeTypeDetector $mimeTypeDetector = null
     ) {
         $this->adapter = new InMemoryFilesystemAdapter(
             $defaultVisibility,
-            $mimeTypeDetector ?? new FinfoMimeTypeDetector,
+            $mimeTypeDetector ?? new FinfoMimeTypeDetector(),
         );
+        $this->defaultVisibility = $defaultVisibility;
         $this->directories = [];
     }
 
@@ -153,4 +156,3 @@ class TestInMemoryFilesystemAdapter implements FilesystemAdapter
         return '/' . trim($path, '/') . '/';
     }
 }
-


### PR DESCRIPTION
I don't seem to be able to specify 0.4.0 as the target for the PR.

`::directoryExists()` is a Flysystem 3.0 function which I call when it's available, otherwise I have a re-implementation.

This is working well in my integration tests for https://github.com/BrianHenryIE/strauss/pull/139

Closes #15 !