### PR TITLE
Catch exceptions; return `false`

### DIFF
--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -261,11 +261,20 @@ class StreamWrapper
         return true;
     }
 
-    public function stream_read(int $count): string
+    /**
+     * @param int $count
+     *
+     * @return false|string
+     */
+    public function stream_read(int $count)
     {
         $this->log('info', __METHOD__, func_get_args());
-        $this->openRead();
-        return stream_get_contents($this->read, $count);
+        try {
+            $this->openRead();
+            return stream_get_contents($this->read, $count);
+        } catch (Throwable $e) {
+            return false;
+        }
     }
 
     public function stream_seek(int $offset, int $whence = SEEK_SET): bool
@@ -297,8 +306,12 @@ class StreamWrapper
     public function stream_stat()
     {
         $this->log('info', __METHOD__);
-        $this->openRead();
-        return fstat($this->read);
+        try {
+            $this->openRead();
+            return fstat($this->read);
+        } catch (Throwable $e) {
+            return false;
+        }
     }
 
     public function stream_tell(): int

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -258,6 +258,17 @@ class StreamWrapper
         $this->log('info', __METHOD__, func_get_args());
         $this->path = $path;
         $this->mode = $mode;
+
+        // Attempt to open for reading if mode is read or read/write
+        if (strpbrk($mode, 'r+') !== false) {
+            try {
+                $this->openRead();
+            } catch (\Throwable $e) {
+                $this->log('error', __METHOD__, ['exception' => $e]);
+                return false;
+            }
+        }
+
         return true;
     }
 
@@ -273,6 +284,9 @@ class StreamWrapper
             $this->openRead();
             return stream_get_contents($this->read, $count);
         } catch (Throwable $e) {
+            $this->log('error', __METHOD__, func_get_args() + [
+                'exception' => $e,
+            ]);
             return false;
         }
     }
@@ -310,6 +324,9 @@ class StreamWrapper
             $this->openRead();
             return fstat($this->read);
         } catch (Throwable $e) {
+            $this->log('error', __METHOD__, func_get_args() + [
+                'exception' => $e,
+            ]);
             return false;
         }
     }

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -277,3 +277,10 @@ it('can read and write to a Flysystem filesystem', function () {
 
     expect($actual)->toBe($expected);
 });
+
+it('it returns false for file_get_contents missing file', function () {
+
+    $actual = file_get_contents("fly://doesnotexist.txt");
+
+    expect($actual)->toBe(false);
+});

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -119,6 +119,8 @@ it('can handle writes that force a buffer flush', function () {
 });
 
 it('can acquire multiple shared locks', function () {
+    touch('fly://foo');
+
     $stream1 = fopen('fly://foo', 'r');
     $result = flock($stream1, LOCK_SH);
     expect($result)->toBeTrue();
@@ -148,6 +150,8 @@ it('cannot acquire multiple exclusive locks', function () {
 });
 
 it('cannot acquire an exclusive lock with existing locks', function () {
+    touch('fly://foo');
+
     $stream1 = fopen('fly://foo', 'r');
     $result = flock($stream1, LOCK_SH);
     expect($result)->toBeTrue();
@@ -278,9 +282,8 @@ it('can read and write to a Flysystem filesystem', function () {
     expect($actual)->toBe($expected);
 });
 
-it('it returns false for file_get_contents missing file', function () {
-
-    $actual = file_get_contents("fly://doesnotexist.txt");
+it('fails attempting to read a missing file', function () {
+    $actual = @file_get_contents("fly://doesnotexist.txt");
 
     expect($actual)->toBe(false);
 });


### PR DESCRIPTION
PHP's [`file_get_contents()`](https://www.php.net/manual/en/function.file-get-contents.php) just returns `false` when a file cannot be found.

```php
$result = @file_get_contents('doesnotexist.txt'); 
echo $result === false ? 'false' : $result;
```
> false

I've been using this to wrap `League\Flysystem\Local\LocalFilesystemAdapter` which throws exceptions when trying to read a file that does not exits.

> `League\Flysystem\UnableToReadFile` : Unable to read file from location: /doesnotexist.txt. file does not exist

The test is currently failing with:

> Failed asserting that `''` is identical to `false`.

Any ideas why that might be?

I caught `Throwable` rather than `UnableToReadFile` because I don't know all exceptions that might be thrown, and it seems consistent with the existing code.